### PR TITLE
Fix errors display in login.html.twig

### DIFF
--- a/Resources/views/Security/login.html.twig
+++ b/Resources/views/Security/login.html.twig
@@ -4,7 +4,7 @@
 {% if error %}
     <div class="alert alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-        {{ error|trans({}, 'FOSUserBundle') }}
+        {{ error.messageKey|trans(error.messageData, 'security') }}
     </div>
 {% endif %}
 


### PR DESCRIPTION
According to http://stackoverflow.com/questions/26341728/fosuserbundle-bad-credentials-exception
