### PR TITLE
Update login.html.twig to support FOSUserBundle 2.0.0

### DIFF
--- a/Resources/views/Security/login.html.twig
+++ b/Resources/views/Security/login.html.twig
@@ -4,13 +4,11 @@
 {% if error %}
     <div class="alert alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-        <div>
         {% if error is iterable %}
             {{ error.messageKey|trans(error.messageData, 'security') }}
         {% else %} 
             {{ error|trans({}, 'FOSUserBundle') }}
         {% endif %}
-        </div>
     </div>
 {% endif %}
 

--- a/Resources/views/Security/login.html.twig
+++ b/Resources/views/Security/login.html.twig
@@ -4,7 +4,13 @@
 {% if error %}
     <div class="alert alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-        {{ error.messageKey|trans(error.messageData, 'security') }}
+        <div>
+        {% if error is iterable %}
+            {{ error.messageKey|trans(error.messageData, 'security') }}
+        {% else %} 
+            {{ error|trans({}, 'FOSUserBundle') }}
+        {% endif %}
+        </div>
     </div>
 {% endif %}
 

--- a/Resources/views/Security/login.html.twig
+++ b/Resources/views/Security/login.html.twig
@@ -4,7 +4,7 @@
 {% if error %}
     <div class="alert alert-danger alert-dismissable">
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-        {{ error|trans({}, 'FOSUserBundle') }}
+        {{ error.messageKey|trans(error.messageData, 'security') }}
     </div>
 {% endif %}
 


### PR DESCRIPTION
From https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Changelog.md

[BC break] The FOSUserBundle:Security:login.html.twig template now receives an AuthenticationException in the error variable rather than an error message.
